### PR TITLE
fix aws provider credential missing error.

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -1,6 +1,8 @@
 # Set the cloud provider to AWS
 provider "aws" {
-  region = var.aws_region
+  region     = var.aws_region
+  access_key = var.aws_access_key_id
+  secret_key = var.aws_secret_access_key
 }
 
 #~~~~~~~~~~~~~~~~~~~~~~~~~~~#


### PR DESCRIPTION
Fix aws provider credential missing error:

```
data.template_file.cloud-init: Refreshing state...

Error: error configuring Terraform AWS Provider: no valid credential sources for Terraform AWS Provider found.

Please see https://registry.terraform.io/providers/hashicorp/aws
for more information about providing credentials.

Error: NoCredentialProviders: no valid providers in chain
caused by: EnvAccessKeyNotFound: failed to find credentials in the environment.
SharedCredsLoad: failed to load profile, .
EC2RoleRequestError: no EC2 instance role found
caused by: EC2MetadataError: failed to make EC2Metadata request
404 Not Found

The resource could not be found.


	status code: 404, request id:


  on main.tf line 2, in provider "aws":
   2: provider "aws" {
```